### PR TITLE
🔧  Trigger CD on github tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,8 @@ name: cd
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   docker:
@@ -23,4 +23,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/github-changelog:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/github-changelog:${{ github.ref_name }}


### PR DESCRIPTION
Instead of building and deploying the docker image every time a merge in done on the main branch and replace the latest version, the build of the docker image is triggered on a github tag creation and this tag name is used to tag the docker image.