### PR TITLE
🔧  Add `curl` in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM oven/bun:1.0
 
+RUN \
+  apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    curl \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
 WORKDIR /usr/src/app
 
 COPY package.json bun.lockb ./


### PR DESCRIPTION
This is needed by the slack orb.
It is easier to add it in this docker image.